### PR TITLE
Starred backend

### DIFF
--- a/balto-api/app.js
+++ b/balto-api/app.js
@@ -5,6 +5,7 @@ const { PORT } = require("./config")
 const security = require("./middleware/security")
 const authRoutes = require("./routes/auth")
 const dogRecordsRoutes = require("./routes/dog-records")
+const userRoutes = require("./routes/user")
 
 const { BadRequestError, NotFoundError } = require("./utils/errors")
 
@@ -18,6 +19,7 @@ app.use(security.extractUserFromJwt)
 
 app.use("/auth", authRoutes)
 app.use("/dog-records", dogRecordsRoutes)
+app.use("/user", userRoutes)
 
 
 // 404 error handler

--- a/balto-api/models/starred
+++ b/balto-api/models/starred
@@ -50,6 +50,8 @@ class Starred {
             RETURNING id
             `
         const result = await db.query(query, [userId, dogId])
+
+        // checking if the query actually deleted anything (if the pairing exists)
         if (result.rowCount == 0) {
             throw new BadRequestError("Pairing does not exist")
         }

--- a/balto-api/models/starred
+++ b/balto-api/models/starred
@@ -1,0 +1,79 @@
+const db = require("../db")
+const { UnauthorizedError, BadRequestError } = require("../utils/errors")
+
+class Starred {
+
+    // called in GET request to /user/starred
+    static async listStarredDogsForUser(userId) {
+        if (!userId) {
+            throw new BadRequestError("No userId")
+        }
+
+        const query = `
+            SELECT * FROM user_dog_pairings
+            WHERE user_id = $1
+            ORDER BY created_at ASC
+            `
+        const result = await db.query(query, [userId])
+        return result.rows
+    }
+
+    // called in POST response to /user/starred
+    static async createUserDogPairing(userId, dogId) {
+        // make sure there isn't already a pairing with the two supplied IDs
+        const existingPairing = await Starred.fetchUserDogPairing(userId, dogId)
+        if (existingPairing) {
+            throw new BadRequestError("Duplicate pairing")
+        }
+
+        const query = `
+            INSERT INTO user_dog_pairings (user_id, dog_id)
+            VALUES ($1, $2)
+            RETURNING *
+            `     
+        const result = await db.query(query, [userId, dogId])
+        return result.rows
+    }
+
+    // called in DELETE response to /user/starred
+    static async deleteUserDogPairing(userId, dogId) {
+        if (!userId) {
+            throw new BadRequestError("No userId provided")
+        }
+        if (!dogId) {
+            throw new BadRequestError("No dogId provided")
+        }
+
+        const query = `
+            DELETE FROM user_dog_pairings
+            WHERE user_id = $1 AND dog_id = $2
+            RETURNING id
+            `
+        const result = await db.query(query, [userId, dogId])
+        if (result.rowCount == 0) {
+            throw new BadRequestError("Pairing does not exist")
+        }
+    }
+
+
+    // check if there is already a specific user dog pairing in the database
+    static async fetchUserDogPairing(userId, dogId) {
+        console.log("in fetchUserDogPairing", userId, dogId)
+        if (!userId) {
+            throw new BadRequestError("No userId provided")
+        }
+        if (!dogId) {
+            throw new BadRequestError("No dogId provided")
+        }
+
+        const query = `
+            SELECT * FROM user_dog_pairings
+            WHERE user_id = $1 AND dog_id = $2
+            `
+        const result = await db.query(query, [userId, dogId])
+        return result.rows[0]
+    }
+
+}
+
+module.exports = Starred

--- a/balto-api/routes/user.js
+++ b/balto-api/routes/user.js
@@ -1,0 +1,41 @@
+const express = require("express")
+const router = express.Router()
+const Starred = require("../models/starred")
+const security = require("../middleware/security")
+
+// get all user-dog pairings for the user
+router.get("/starred", security.requireAuthenticatedUser, async (req, res, next) => {
+    try {
+        const { userId } = res.locals.user
+        const starredDogs = await Starred.listStarredDogsForUser(userId)
+        return res.status(200).json({ starredDogs })
+    } catch(err) {
+        next(err)
+    }
+})
+
+  // star a dog; create a new user_dog pairing in the database
+  router.post("/starred", security.requireAuthenticatedUser, async (req, res, next) => {
+    try {
+        const { userId } = res.locals.user
+        const { dogId } = req.body
+        const userDogPairing = await Starred.createUserDogPairing(userId, dogId)
+        return res.status(200).json({ userDogPairing })
+    } catch (err) {
+        next(err)
+    }
+  })
+
+  // unstar a dog; delete a user_dog pairing in the database
+  router.delete("/starred/", security.requireAuthenticatedUser, async (req, res, next) => {
+    try {
+        const { userId } = res.locals.user
+        const { dogId } = req.body
+        await Starred.deleteUserDogPairing(userId, dogId)
+        return res.status(204).send("Resource successfully deleted")
+    } catch (err) {
+        next(err)
+    }
+  })
+
+module.exports = router


### PR DESCRIPTION
- GET, POST, and DELETE endpoints for getting all user-dog pairings, creating a new user-dog pairing, and deleting a user-dog-pairing
- Changed the endpoints from our project plan (/user/starred/:dogId to just /user/starred): thought that we should include dogId as part of the **request body** rather than as a request path parameter (the :dogId part) because it seems like regular practice is to use path parameters when it's acting on a specific unique resource in our database tables. In our case that'd be the user_dog_pairing row, but since we're not actually utilizing the user_dog_pairing id to delete the row, I think using a header parameter wouldn't fit here since multiple users should be able to remove a specific dog from their favorites list. Not 100% sure about this, though.